### PR TITLE
fix(logging): Route process errors and progress to OpenOrchestrator log

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4] - 08-06-2026
+
+- Fixed silent failure: per-file processing errors are now logged to OpenOrchestrator via `log_error` (not just stdout) and the whole run is marked as failed by raising `RuntimeError` after the loop when any file failed.
+- Threaded `orchestrator_connection` through `execute_sql_string_with_validation`, `execute_sql_file_with_validation`, and `_process_validation_results` so SQL execution progress and validation metrics also surface in the OO log via `log_info` and `log_trace`.
+
 ## [1.1.3] - 04-06-2026
 
 - Fixed missing error-email value in config

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "robot_framework"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="ITK Development", email="itk-rpa@mkb.aarhus.dk" },
 ]

--- a/robot_framework/ode_ingest/run_sql_transforms.py
+++ b/robot_framework/ode_ingest/run_sql_transforms.py
@@ -16,13 +16,15 @@ from OpenOrchestrator.orchestrator_connection.connection import OrchestratorConn
 from robot_framework import config
 
 
-def _process_validation_results(rows, log_key: str, validation_log: dict) -> None:
+def _process_validation_results(rows, log_key: str, validation_log: dict,
+                                orchestrator_connection: OrchestratorConnection) -> None:
     """Process validation query results and log metrics.
 
     Args:
         rows: Query result rows
         log_key: Key for validation log entry
         validation_log: Dictionary to store validation results
+        orchestrator_connection: OO connection used to surface metrics in the central log.
     """
     if not rows:
         return
@@ -31,7 +33,9 @@ def _process_validation_results(rows, log_key: str, validation_log: dict) -> Non
 
     # NULL in primary key report
     if 'NULL_IN_PRIMARY_KEY' in str(first_row):
-        print(f"  ⚠ Found {len(rows)} rows with NULL in primary key")
+        msg = f"Found {len(rows)} rows with NULL in primary key"
+        print(msg)
+        orchestrator_connection.log_info(msg)
         validation_log[log_key]['issues'].append({
             'type': 'null_in_primary_key',
             'count': len(rows),
@@ -41,18 +45,25 @@ def _process_validation_results(rows, log_key: str, validation_log: dict) -> Non
     # Row count metrics
     elif 'ROW_COUNTS' in str(first_row):
         row_dict = dict(first_row._mapping)  # pylint: disable=protected-access
-        print(f"  Source rows: {row_dict.get('source_rows', 'N/A')}")
-        print(f"  Target rows: {row_dict.get('target_rows', 'N/A')}")
+        src_msg = f"Source rows: {row_dict.get('source_rows', 'N/A')}"
+        tgt_msg = f"Target rows: {row_dict.get('target_rows', 'N/A')}"
+        print(src_msg)
+        print(tgt_msg)
+        orchestrator_connection.log_trace(src_msg)
+        orchestrator_connection.log_trace(tgt_msg)
         if 'excluded_rows' in row_dict:
             excluded = row_dict['excluded_rows']
             if excluded > 0:
-                print(f"  ⚠ Excluded rows: {excluded}")
+                msg = f"Excluded rows: {excluded}"
+                print(msg)
+                orchestrator_connection.log_info(msg)
 
         validation_log[log_key]['row_counts'] = row_dict
 
 
 def execute_sql_string_with_validation(sql_content: str, engine,
-                                       validation_log: dict, log_key: str) -> None:
+                                       validation_log: dict, log_key: str,
+                                       orchestrator_connection: OrchestratorConnection) -> None:
     """Execute SQL transformation script string and capture validation metrics.
 
     Splits SQL content by GO statements and executes each batch separately.
@@ -63,11 +74,15 @@ def execute_sql_string_with_validation(sql_content: str, engine,
         engine: SQLAlchemy engine for database connection
         validation_log: Dictionary to store validation results (modified in-place)
         log_key: Key for the validation log entry
+        orchestrator_connection: OO connection used to forward progress and
+            SQL-execution errors to OO's log in addition to stdout.
 
     Raises:
         Exception: Re-raises any SQL execution errors after logging them
     """
-    print(f"\nExecuting transformation for {log_key}...")
+    msg = f"Executing transformation for {log_key}..."
+    print(msg)
+    orchestrator_connection.log_trace(msg)
 
     # Split by GO statements
     batches = [batch.strip() for batch in sql_content.split('GO\n') if batch.strip()]
@@ -95,7 +110,8 @@ def execute_sql_string_with_validation(sql_content: str, engine,
                 if batch.strip().upper().startswith(('SELECT', 'WITH')):
                     try:
                         rows = result.fetchall()
-                        _process_validation_results(rows, log_key, validation_log)
+                        _process_validation_results(rows, log_key, validation_log,
+                                                    orchestrator_connection=orchestrator_connection)
                     except ResourceClosedError:
                         # Some queries don't return results (INSERT, CREATE, etc)
                         pass
@@ -103,17 +119,23 @@ def execute_sql_string_with_validation(sql_content: str, engine,
                 connection.commit()
 
             except SQLAlchemyError as exc:
-                print(f"  ✗ Error in batch {i}: {exc}")
+                err_msg = f"Error in batch {i}: {exc}"
+                print(err_msg)
+                orchestrator_connection.log_error(err_msg)
                 validation_log[log_key]['status'] = 'failed'
                 validation_log[log_key]['error'] = str(exc)
                 raise
 
     validation_log[log_key]['status'] = 'completed'
-    print("  ✓ Transformation completed")
+    done_msg = "Transformation completed"
+    print(done_msg)
+    orchestrator_connection.log_trace(done_msg)
 
 
 def execute_sql_file_with_validation(filepath: Path, engine,
-                                     validation_log: dict, log_key: str = None) -> None:
+                                     validation_log: dict,
+                                     orchestrator_connection: OrchestratorConnection,
+                                     log_key: str = None) -> None:
     """Execute SQL transformation script from file and capture validation metrics.
 
     Wrapper around execute_sql_string_with_validation that reads from a file.
@@ -122,12 +144,16 @@ def execute_sql_file_with_validation(filepath: Path, engine,
         filepath: Path to the SQL transformation script
         engine: SQLAlchemy engine for database connection
         validation_log: Dictionary to store validation results (modified in-place)
+        orchestrator_connection: OO connection, threaded through to
+            ``execute_sql_string_with_validation`` for centralized logging.
         log_key: Optional custom key for the validation log entry (defaults to filename)
 
     Raises:
         Exception: Re-raises any SQL execution errors after logging them
     """
-    print(f"\nExecuting {filepath.name}...")
+    msg = f"Executing {filepath.name}..."
+    print(msg)
+    orchestrator_connection.log_trace(msg)
 
     with open(filepath, 'r', encoding='utf-8') as f:
         sql_content = f.read()
@@ -136,10 +162,13 @@ def execute_sql_file_with_validation(filepath: Path, engine,
         log_key = filepath.stem.replace('transform_', '')
 
     # Update to use file name in log
-    execute_sql_string_with_validation(sql_content, engine, validation_log, log_key)
+    execute_sql_string_with_validation(sql_content, engine, validation_log, log_key,
+                                       orchestrator_connection=orchestrator_connection)
     # Override the script name to show actual file
     validation_log[log_key]['script'] = filepath.name
-    print(f"  ✓ {filepath.name} completed")
+    done_msg = f"{filepath.name} completed"
+    print(done_msg)
+    orchestrator_connection.log_trace(done_msg)
 
 
 def run_all_transforms(sql_dir: Path, oc,
@@ -168,9 +197,10 @@ def run_all_transforms(sql_dir: Path, oc,
 
     for script_file in table_scripts:
         try:
-            execute_sql_file_with_validation(script_file, engine, validation_log)
+            execute_sql_file_with_validation(script_file, engine, validation_log,
+                                             orchestrator_connection=oc)
         except SQLAlchemyError as exc:
-            print(f"\n✗ Failed to execute {script_file.name}")
+            print(f"\nFailed to execute {script_file.name}")
             print(f"  Error: {exc}")
 
             # response = input("\nContinue with remaining scripts? (y/n): ")
@@ -203,13 +233,13 @@ def run_all_transforms(sql_dir: Path, oc,
     ]
 
     if tables_with_issues:
-        print(f"\n⚠ Tables with validation issues: {len(tables_with_issues)}")
+        print(f"\nTables with validation issues: {len(tables_with_issues)}")
         for table in tables_with_issues:
             issues = validation_log[table]['issues']
             for issue in issues:
                 print(f"  - {table}: {issue['type']} ({issue['count']} rows)")
 
-    print(f"\n✓ Detailed validation log saved to: {validation_log_file}")
+    print(f"\nDetailed validation log saved to: {validation_log_file}")
     print("="*70)
 
 
@@ -222,7 +252,8 @@ if __name__ == "__main__":
 
     conn_str = oc_main.get_constant(config.DB_CONNECTION).value
     db_engine = create_engine(conn_str)
-    execute_sql_file_with_validation(Path("sql_transforms/transform_RIM-aftale-rater_Delta.sql"), db_engine, {})
+    execute_sql_file_with_validation(Path("sql_transforms/transform_RIM-aftale-rater_Delta.sql"), db_engine, {},
+                                     orchestrator_connection=oc_main)
     # if not sql_dir.exists():
     #     print(f"Error: Directory {sql_dir} not found")
     #     print("Run generate_transform_sql.py first to generate scripts")

--- a/robot_framework/process.py
+++ b/robot_framework/process.py
@@ -8,6 +8,7 @@ This module orchestrates the complete data pipeline:
 """
 import json
 import os
+import traceback
 from pathlib import Path
 
 from OpenOrchestrator.orchestrator_connection.connection import OrchestratorConnection
@@ -46,10 +47,13 @@ def process(orchestrator_connection: OrchestratorConnection) -> None:
             with open(validation_log_file, 'r', encoding='utf-8') as f:
                 validation_log = json.load(f)
         except json.JSONDecodeError:
-            print("Could not read existing log file (possibly empty or corrupt). Starting new.")
+            msg = "Could not read existing log file (possibly empty or corrupt). Starting new."
+            print(msg)
+            orchestrator_connection.log_info(msg)
 
     directory = orchestrator_connection.get_constant(config.DATA_DIRECTORY).value
     tables_to_process = config.TABLES_TO_PROCESS or table_definitions.ALL_TABLE_NAMES
+    file_failures: list[str] = []
     for table_name in tables_to_process:
         table_schema = table_definitions.all_tables.get(table_name).data_types
         table_schema.update(table_definitions.metadata_columns)
@@ -66,9 +70,13 @@ def process(orchestrator_connection: OrchestratorConnection) -> None:
                 stats = {}
                 try:
                     df, stats = ingest_utils.process_file(file_path, table_name)
-                    print(f"\nLoaded file {file_path}: \n{stats}.")
+                    msg = f"Loaded file {file_path}: {stats}."
+                    print(msg)
+                    orchestrator_connection.log_info(msg)
                     df.to_sql(f"{table_name}_{subset}_Staging", engine, schema=config.DB_SCHEMA, if_exists='append', index=False)
-                    print(f"\nStaged {table_name}_{subset}.")
+                    msg = f"Staged {table_name}_{subset}."
+                    print(msg)
+                    orchestrator_connection.log_info(msg)
 
                     # Generate and execute SQL transformation in-memory
                     sql_script = generate_transform_sql.generate_transform_script_string(
@@ -80,18 +88,29 @@ def process(orchestrator_connection: OrchestratorConnection) -> None:
                     )
                     run_sql_transforms.execute_sql_string_with_validation(
                         sql_script, engine, validation_log,
-                        log_key=f"{table_name}_{subset} ({file_path.name})"
+                        log_key=f"{table_name}_{subset} ({file_path.name})",
+                        orchestrator_connection=orchestrator_connection,
                     )
 
                     file_utils.move_processed_files(file_path)
                     ingest_utils.log_ingest_stats(engine=engine, table_name=f"{table_name}_{subset}", filename=file_path.name, stats=stats, status="Success")
                 except Exception as e:  # pylint: disable=broad-exception-caught
-                    print(f"  ✗ FEJL ved behandling af {file_path.name}: {e}")
+                    failure_descriptor = f"{table_name}_{subset}/{file_path.name}"
+                    error_msg = f"FEJL ved behandling af {failure_descriptor}: {e!r}\n\n{traceback.format_exc()}"
+                    print(error_msg)
+                    orchestrator_connection.log_error(error_msg)
                     ingest_utils.log_ingest_stats(engine=engine, table_name=f"{table_name}_{subset}", filename=file_path.name, stats=stats, status="Fail", error=str(e))
+                    file_failures.append(failure_descriptor)
                     break
 
                 with open(validation_log_file, 'w', encoding='utf-8') as f:
                     json.dump(validation_log, f, indent=2)
+
+    if file_failures:
+        raise RuntimeError(
+            f"Process completed with {len(file_failures)} file failure(s): "
+            + ", ".join(file_failures)
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Per-file errors now log_error to OO with stack trace, and process() raises RuntimeError when any file fails so the whole job is marked as failed (was previously failing silently in stdout only).

# Beskrivelse
- Rodårsag: Manglende logging, vi brugte kun print
- Løsning/ændringer: Tilføjede orchestrator_connection.log_*
- Påvirkning/risici (downstream, rapporter, performance): NA

## Tjekliste
- [x] Følger CONTRIBUTING.md (branchnavn, Conventional Commits, ingen genereret SQL committed)
- [x] Changelog opdateret (changelog.md)
- [x] Version bump i pyproject.toml
- [x] Testet lokalt (beskriv kort hvordan)
- [x] Ingen breaking changes for API/kontrakter (eller beskriv nedenfor)
- [x] Dokumentation opdateret hvis relevant (README/changelog/notes)

## Datakørsel (hvis relevant)
- [x] DDL/ændringer i DB‑skema kræves ikke
  - eller:
    - [x] DDL vedlagt/beskrevet
    - [x] Backfill/cleanup‑trin beskrevet

## Validering (hvis relevant)
- [x] Metrikker/queries for at bekræfte output (fx counts, NULL‑tjek) er vedlagt

## Screenshots/Logs (valgfrit)

## Relaterede sager
Closes #<issue>, Relates‑to #<issue>

## Breaking changes (hvis nogen)
- Beskriv migrations/kommunikation til forbrugere
